### PR TITLE
Fix more compilation errors on Visual Studio 2017.

### DIFF
--- a/libs/ButeMgr/butemgr.h
+++ b/libs/ButeMgr/butemgr.h
@@ -31,6 +31,7 @@
 #	include <iosfwd>
 #	include <strstream>
 #	include <iostream>
+#	include <fstream>
 #elif defined(__LINUX)
 #   include <unordered_set>
 #   include <unordered_map>
@@ -668,8 +669,10 @@ inline bool CButeMgr::Parse(void* pData, unsigned long size, int decryptCode,
 {
 	if (!pData)
 		return false;
+	std::streamsize len = size;
+	const char* buf1 = (const char*)pData;
 #if _MSC_VER >= 1300 && !defined(__clang__)
-	std::istrstream IStream{(char*)pData, size};
+	std::istrstream IStream(buf1, len);
 #elif defined(__LINUX)
 	std::istringstream IStream{std::string{(char*)pData, size}};
 #else
@@ -687,7 +690,7 @@ inline bool CButeMgr::Parse(void* pData, unsigned long size, const char* cryptKe
 {
 	if (!pData)
 		return false;
-	char* buf1 = (char*)pData;
+	const char* buf1 = (const char*)pData;
 #if _MSC_VER >= 1300 && !defined(__clang__)
 	std::streamsize len = size;
 	std::istrstream Iss(buf1, len);

--- a/runtime/sound/src/sys/s_dx8/s_dx8.cpp
+++ b/runtime/sound/src/sys/s_dx8/s_dx8.cpp
@@ -5374,7 +5374,7 @@ S32	CDx8SoundSys::DecompressADPCM( LTSOUNDINFO* pInfo, void** ppOutData, U32* pu
 */
 }
 
-S32	CDx8SoundSys::DecompressASI( void* pInData, U32 uiInSize,const char* sFilename_ext, void** ppWav, U32* puiWavSize, LTLENGTHYCB fnCallback )
+S32	CDx8SoundSys::DecompressASI( void* pInData, U32 uiInSize, char* sFilename_ext, void** ppWav, U32* puiWavSize, LTLENGTHYCB fnCallback )
 {
 	bool bSuccess = false;
 

--- a/runtime/sound/src/sys/s_dx8/s_dx8.h
+++ b/runtime/sound/src/sys/s_dx8/s_dx8.h
@@ -429,7 +429,7 @@ public:
 
 	// wave file decompression functons
 	virtual S32			DecompressADPCM( LTSOUNDINFO* pInfo, void** ppOutData, U32* puiOutSize );
-	virtual S32			DecompressASI( void* pInData, U32 uiInSize, const char* sFilename_ext, void** ppWav, U32* puiWavSize, LTLENGTHYCB fnCallback );
+	virtual S32			DecompressASI( void* pInData, U32 uiInSize, char* sFilename_ext, void** ppWav, U32* puiWavSize, LTLENGTHYCB fnCallback );
 	UINT				ReadStream( WaveFile* pStream, BYTE* pOutBuffer, int nSize );
 	BYTE*				GetCompressedBuffer() { return m_pCompressedBuffer; }
 	BYTE*				GetDecompressedBuffer() { return m_pDecompressedBuffer; }

--- a/runtime/ui/src/cuidebug.h
+++ b/runtime/ui/src/cuidebug.h
@@ -24,7 +24,6 @@
 #define __STDARG_H__
 #endif
 
-
 //  --------------------------------------------------------------------------
 // 	CUI Debugging tools
 //  --------------------------------------------------------------------------
@@ -37,7 +36,11 @@
 
 	If __DEBUG and _DEBUG are not defined, CUI_PRINT resolves to a comment.
 */
+#if _MSC_VER >= 1300
+#define CUI_PRINT(x, ...) CUIDebug::DebugPrint(x, __VA_ARGS__)
+#else
 #define CUI_PRINT(x, ...) CUIDebug::DebugPrint(x __VA_OPT(,) __VA_ARGS__)
+#endif
 
 
 /*!
@@ -56,7 +59,12 @@
 
 	If __DEBUG and _DEBUG are not defined, CUI_DBG resolves to a comment.
 */
+#if _MSC_VER >= 1300
+#define CUI_DBG(x, ...) CUIDebug::DebugPrint("%s: ", this->GetClassName()); CUIDebug::DebugPrint(x, __VA_ARGS__)
+#else
 #define CUI_DBG(x, ...) CUIDebug::DebugPrint("%s: ", this->GetClassName()); CUIDebug::DebugPrint(x __VA_OPT(,) __VA_ARGS__)
+#endif
+
 
 
 /*!
@@ -71,7 +79,12 @@
 	to be sucessful, even though 2 functions are being called and the conditional
 	does not enclose a new code block in curly braces '{}'.
 */
+#if _MSC_VER >= 1300
+#define CUI_ERR(x, ...) CUIDebug::DebugPrint("Error in %s at line %i:\n    ", __FILE__, __LINE__); CUIDebug::DebugPrint(x, __VA_ARGS__)
+#else
 #define CUI_ERR(x, ...) CUIDebug::DebugPrint("Error in %s at line %i:\n    ", __FILE__, __LINE__); CUIDebug::DebugPrint(x __VA_OPT(,) __VA_ARGS__)
+#endif
+
 
 
 /*!


### PR DESCRIPTION
For the cuidebug.h macros, __VA_OPT is not available in VS2017.