### PR TITLE
Fix crash when starting a new game.

### DIFF
--- a/runtime/server/src/server_filemgr.cpp
+++ b/runtime/server/src/server_filemgr.cpp
@@ -394,7 +394,7 @@ const char *IServerFileMgr::GetUsedFilename(UsedFile *pFile)
         return pFile->GetFilename();
     }
     else {
-        return nullptr;
+        return "";
     }
 }
 


### PR DESCRIPTION
This fixes a crash in the WriteString function in genltstream.cpp, which is called in game_serialize.cpp:420 when starting a new game.