### PR TITLE
Fix crash deleting effects when exiting game.

### DIFF
--- a/NOLF2/ClientShellDLL/ClientShellShared/ClientFXDB.cpp
+++ b/NOLF2/ClientShellDLL/ClientShellShared/ClientFXDB.cpp
@@ -217,8 +217,6 @@ void CClientFXDB::Term()
 		pGroupNode = pGroupNode->m_pNext;
 	}
 	m_collGroupFX.RemoveAll();
-
-	UnloadFxDll();
 }
 
 //-----------------------------------------------------------------

--- a/NOLF2/ClientShellDLL/ClientShellShared/ClientFXDB.h
+++ b/NOLF2/ClientShellDLL/ClientShellShared/ClientFXDB.h
@@ -152,6 +152,7 @@ public:
 
 	//finds the data for creating a specific effect key
 	FX_REF*							FindFX(const char *sName);
+	void							UnloadFxDll();
 
 private:
 
@@ -159,7 +160,6 @@ private:
 
 	//for managing the DLL
 	bool							LoadFxDll();
-	void							UnloadFxDll();
 
 	//for loading in the FX files
 	bool							LoadFxGroups(ILTClient* pClient, const char *sName);

--- a/NOLF2/ClientShellDLL/ClientShellShared/ClientFXMgr.cpp
+++ b/NOLF2/ClientShellDLL/ClientShellShared/ClientFXMgr.cpp
@@ -18,6 +18,7 @@
 #include "iltmessage.h"
 #include "iltdrawprim.h"
 #include "ClientFXMgr.h"
+#include "ClientFXDB.h"
 #include "PlayerMgr.h"
 #include "CMoveMgr.h"
 #include "WinUtil.h"
@@ -323,6 +324,7 @@ CClientFXMgr::~CClientFXMgr()
 			g_pCLIENTFX_INSTANCE_Bank = NULL;
 		}
 	}
+	CClientFXDB::GetSingleton().UnloadFxDll();
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
For some reason, calling UnloadFxDll in CClientFXDB::Term() frees some CBaseFX pointers in the m_collActiveFX linked list, resulting in an access violation crash in CLIENTFX_INSTANCE::DeleteFX when exiting the game.