### PR TITLE
Remove unused includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ Rez
 *.REZ
 .vscode
 codeblocks
+
+cmake-build-debug/
+
+.idea/

--- a/runtime/render_b/src/sys/sdl/sdltexinterface.cpp
+++ b/runtime/render_b/src/sys/sdl/sdltexinterface.cpp
@@ -4,7 +4,6 @@
 #include "render.h"
 
 #include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
 
 // interface database
 define_interface(CSysTexInterface, ILTTexInterface);

--- a/runtime/sound/src/sys/linux/sdl.cpp
+++ b/runtime/sound/src/sys/linux/sdl.cpp
@@ -1,5 +1,4 @@
 #include "iltsound.h"
-#include "SDL2/SDL_mixer.h"
 
 typedef sint16	S16;
 typedef uint16	U16;


### PR DESCRIPTION
Hi, seems like some includes are useless, and nowhere used in code.

If this not planned to use in future, maybe remove that lines? 
This should help to build project without installing SDL2_image and SDL2_mixer packages

