### PR TITLE
Fix more issues in WinUtil.cpp.

### DIFF
--- a/NOLF2/Shared/WinUtil.cpp
+++ b/NOLF2/Shared/WinUtil.cpp
@@ -284,6 +284,10 @@ DWORD CWinUtil::WinWritePrivateProfileString (const char* lpAppName, const char*
 	return WritePrivateProfileString (lpAppName, lpKeyName, lpString, lpFileName);
 #else
     // format app.key=str
+	if (lpAppName == NULL || lpKeyName == NULL || lpString == NULL)
+	{
+		return 1;
+	}
 	std::string lookup{lpAppName};
 	lookup += ".";
 	lookup += lpKeyName;

--- a/NOLF2/Shared/WinUtil.cpp
+++ b/NOLF2/Shared/WinUtil.cpp
@@ -256,6 +256,10 @@ DWORD CWinUtil::WinGetPrivateProfileString (const char* lpAppName, const char* l
 	std::string lookup{lpKeyName};
 	std::string line;
 	std::ifstream conf{lpFileName};
+	if (!conf)
+	{
+		return 2;
+	}
 	while(!conf.eof()) {
 		conf >> line;
 		if(line.substr(0, lookup.size()) ==  lookup) {


### PR DESCRIPTION
On my Xubuntu installation, this fixed an infinite loop in WinGetPrivateProfileString.