### PR TITLE
DynRes: Only exlude lines that fully match "end".

### DIFF
--- a/libs/DynRes/rc.parser.py
+++ b/libs/DynRes/rc.parser.py
@@ -20,7 +20,7 @@ def parseRC(rcFile):
                 ret_incl.append(n[1].replace(u'\\', u'/'))
             if u'stringtable' in l.lower():
                 cur_lst = str_table
-            if u'end' in l.lower():
+            if u'end' == l.lower():
                 cur_lst = None
             if l.startswith(u' ') and cur_lst is not None:
                 n = l.strip(u'\n').split(u'"')


### PR DESCRIPTION
This prevents the parser from excluding string codes like IDS_TITLE_ENDMISSION.