### PR TITLE
Initialize iNewWeapon and iRequiredWeapon in GetWeaponTransition.

### DIFF
--- a/NOLF2/ObjectDLL/ObjectShared/AINode.cpp
+++ b/NOLF2/ObjectDLL/ObjectShared/AINode.cpp
@@ -2436,9 +2436,11 @@ const AINodeChangeWeapons::ChangeWeaponSet* const AINodeChangeWeapons::GetWeapon
 		const ChangeWeaponSet& WeaponSet = m_WeaponSets.at(x);
 
 		uint8 iNewAmmo, iNewWeapon;
+		iNewWeapon = g_pWeaponMgr->GetNumWeapons();
 		g_pWeaponMgr->ReadWeapon(const_cast<char*>(WeaponSet.m_szChangeToWeapon.c_str()), iNewWeapon, iNewAmmo );
 
 		uint8 iRequiredAmmo, iRequiredWeapon;
+		iRequiredWeapon = g_pWeaponMgr->GetNumWeapons();
 		g_pWeaponMgr->ReadWeapon(const_cast<char*>(WeaponSet.m_szChangeToWeaponRequirement.c_str()), iRequiredWeapon, iRequiredAmmo );
 
 		const WEAPON* const pRequiredWeapon = g_pWeaponMgr->GetWeapon(iRequiredWeapon);


### PR DESCRIPTION
This fixes a crash when starting the fight with Pierre in Chapter 13
where pRequiredWeapon and pNewWeapon are incorrectly set to non-NULL
because iRequiredWeapon and iNewWeapon are default initialized to zero.
On Windows, they are initialized to a number larger than the WeaponMgr's
m_nNumWeapons, leading IsValidWeaponId() to correctly return false and
continue the loop. On Linux, IsValidWeaponId() returns true, leading the function
to call ReadWeapon from a NULL holster string.