### PR TITLE
Don't use the parent AIVolume class in CAIStimulusRecord.

### DIFF
--- a/NOLF2/ObjectDLL/ObjectShared/AIStimulusMgr.cpp
+++ b/NOLF2/ObjectDLL/ObjectShared/AIStimulusMgr.cpp
@@ -184,7 +184,7 @@ void CAIStimulusRecord::Load(ILTMessage_Read *pMsg)
 	LOAD_DWORD_CAST(m_eTargetMatchID, EnumAITargetMatchID);
 	LOAD_VECTOR(m_vStimulusPos);
 	LOAD_VECTOR(m_vStimulusDir);
-	LOAD_COBJECT(m_pInformationVolume, AIVolume);
+	LOAD_COBJECT(m_pInformationVolume, AIInformationVolume);
 	LOAD_DWORD(m_nStimulusAlarmLevel);
 	LOAD_FLOAT(m_fDistance);
 	LOAD_TIME(m_fTimeStamp);
@@ -540,7 +540,7 @@ EnumAIStimulusID CAIStimulusMgr::_RegisterStimulus(CAIStimulusRecord* pAIStimulu
 		CCharacter* pCharacter = dynamic_cast<CCharacter*>(g_pLTServer->HandleToObject( pAIStimulusRecord->m_hStimulusSource ));
 		if( pCharacter && pCharacter->HasCurrentInformationVolume() )
 		{
-			pAIStimulusRecord->m_pInformationVolume = (AIVolume*)pCharacter->GetCurrentInformationVolume();
+			pAIStimulusRecord->m_pInformationVolume = pCharacter->GetCurrentInformationVolume();
 		}
 	}
 
@@ -1153,7 +1153,7 @@ void CAIStimulusMgr::Update()
 					CCharacter* pCharacter = dynamic_cast<CCharacter*>(g_pLTServer->HandleToObject( pRecord->m_hStimulusSource ));
 					if( pCharacter && pCharacter->HasCurrentInformationVolume() )
 					{
-						pRecord->m_pInformationVolume = (AIVolume*)pCharacter->GetCurrentInformationVolume();
+						pRecord->m_pInformationVolume = pCharacter->GetCurrentInformationVolume();
 					}
 					else
 					{
@@ -1459,7 +1459,7 @@ bool CAIStimulusMgr::CanSense( IAISensing* pSensing, CAIStimulusRecord* pRecord 
 			CAI* pAI = (CAI*)pSensing;
 			if( !pAI->IsSuspicious() )
 			{
-				AIInformationVolume* pInfoVolume = dynamic_cast<AIInformationVolume*>(pRecord->m_pInformationVolume );
+				AIInformationVolume* pInfoVolume = pRecord->m_pInformationVolume;
 				if( pInfoVolume	&& pInfoVolume->IsOn() )
 				{
 					flagsSenseMask = pInfoVolume->GetSenseMask();

--- a/NOLF2/ObjectDLL/ObjectShared/AIStimulusMgr.h
+++ b/NOLF2/ObjectDLL/ObjectShared/AIStimulusMgr.h
@@ -25,7 +25,7 @@
 // Forward declarations.
 class CAIStimulusMgr;
 class CAI;
-class AIVolume;
+class AIInformationVolume;
 class RelationSet;
 class RelationData;
 class IAISensing;
@@ -97,7 +97,7 @@ class CAIStimulusRecord : public CAIClassAbstract
 		LTObjRefNotifier	m_hStimulusSource;		// Handle to source of stimulus.
 		LTObjRefNotifier	m_hStimulusTarget;		// Handle to target of stimulus (optional).
 		EnumAITargetMatchID	m_eTargetMatchID;		// ID used to match stimuli affecting the same object.
-		AIVolume*			m_pInformationVolume;	// Volume where stimulus occured, for sense masks.
+		AIInformationVolume* m_pInformationVolume;	// Volume where stimulus occured, for sense masks.
 		RelationData		m_RelationData;			// Data describing who the emitter was
 		
 		typedef std::vector<CharacterAlignment> _listAlignments;


### PR DESCRIPTION
Taken from https://github.com/haekb/nolf2-modernizer/commit/b7888562e35f014cd7efc1b03c4088a9f284c6a0
This fixes AI ignoring sensemasks, which is noticeable in India, where certain guards
consider you an intruder when they should not.