### PR TITLE
Fix WinWritePrivateProfileString, and correctly check mkdir return value.

### DIFF
--- a/NOLF2/Shared/WinUtil.cpp
+++ b/NOLF2/Shared/WinUtil.cpp
@@ -111,7 +111,7 @@ BOOL CWinUtil::CreateDir (char const* strPath)
 		if (!DirExist (strPartialPath) && strPartialPath[strlen(strPartialPath) - 1] != ':')
 		{
 #ifdef __LINUX
-			if (!mkdir(strPartialPath, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) return FALSE;
+			if (mkdir(strPartialPath, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0) return FALSE;
 #else
 			if (!CreateDirectory(strPartialPath, NULL)) return FALSE;
 #endif
@@ -295,15 +295,18 @@ DWORD CWinUtil::WinWritePrivateProfileString (const char* lpAppName, const char*
 	{
 		return 1;
 	}
-	std::fstream conf{lpFileName, std::ios_base::app|std::ios_base::in|std::ios_base::out};
-	// we've asked to append to the file, so if our write position and read
-	// then it was newly created and we write our app/key
-	if (conf.tellp() == conf.tellg()){
+	std::fstream conf{lpFileName, std::ios_base::in};
+
+	if (!conf.is_open()){
+		conf.close();
+		conf.open(lpFileName, std::ios_base::app|std::ios_base::in|std::ios_base::out);
 		conf << '[' << lpAppName << "]\n";
 		conf << lpKeyName << '=' << lpString << '\n';
+		conf.close();
 		return 0;
 	}
-
+	conf.close();
+	conf.open(lpFileName, std::ios_base::app|std::ios_base::in|std::ios_base::out);
 	std::string line;
 	std::string app_name{lpAppName};
 	std::string key_name{lpKeyName};


### PR DESCRIPTION
When opening with std:ios_base::app, tellp() was always equal to tellg(), so the file would always be appended to when making saves.