### PR TITLE
fixed conversion type

### DIFF
--- a/NOLF2/ObjectDLL/ObjectShared/RelationButeMgr.cpp
+++ b/NOLF2/ObjectDLL/ObjectShared/RelationButeMgr.cpp
@@ -1104,7 +1104,7 @@ void CRelationUser::Update(bool bCanRemoveExpiredRelations)
 void CRelationUser::Sync(const CObjectRelationMgr* pObjectRelationMgr)
 {
 	auto SyncObjectRelationMgr = [pRelationMgr = const_cast<CObjectRelationMgr*>(pObjectRelationMgr)] (auto memento) {
-		if(pRelationMgr->GetRelationUser()->HasMatchingRelationMomento(memento->GetDescription()))
+		if(!pRelationMgr->GetRelationUser()->HasMatchingRelationMomento(memento->GetDescription()))
 			pRelationMgr->AddRelation(memento->GetDescription());
 		return true;
 	};


### PR DESCRIPTION
when making the SyncObjectRelationMgr struct function object
into a lambda its predicate got inverted.

Updated it to use the correct test.