### PR TITLE
Compile ObjectDLL with -fno-gnu-unique.

### DIFF
--- a/NOLF2/ObjectDLL/TO2/CMakeLists.txt
+++ b/NOLF2/ObjectDLL/TO2/CMakeLists.txt
@@ -348,7 +348,7 @@ if(MSVC)
     add_definitions(-D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS)	# VC14 deprecated stdext::hash_*
 endif(MSVC)
 if(LINUX)
-    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-Werror -Wno-c++1z-compat -fPIC")
+    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-Werror -Wno-c++1z-compat -fPIC -fno-gnu-unique")
     include_directories(${CMAKE_SOURCE_DIR}/json/single_include)
 endif(LINUX)
 


### PR DESCRIPTION
This allows CTO2GameServerShell's destructor to be called
whenever the player exits back to the main menu instead of
when the program closes, preventing crashes when exiting the game.