### PR TITLE
OpenAL: Set a streaming sound's position after resuming them.

### DIFF
--- a/runtime/sound/src/soundinstance.cpp
+++ b/runtime/sound/src/soundinstance.cpp
@@ -855,8 +855,8 @@ LTRESULT CSoundInstance::StartRendering( )
 		else
 		{
 			dwCurPos = m_dwDuration - m_dwTimer;
-			GetSoundSys()->SetStreamMsPosition( m_hStream, dwCurPos );
-			GetSoundSys()->PauseStream( m_hStream, 0 );
+			GetSoundSys()->PauseStream(m_hStream, 0);
+			GetSoundSys()->SetStreamMsPosition(m_hStream, dwCurPos);
 		}
 	}
 	else if( m_h3DSample )


### PR DESCRIPTION
This fixes dialog not resuming when the player pauses and resumes gameplay.