### PR TITLE
Fix some issues with Windows/Visual Studio.

### DIFF
--- a/runtime/kernel/src/genericmusic_impl.cpp
+++ b/runtime/kernel/src/genericmusic_impl.cpp
@@ -18,6 +18,7 @@ static IClientFileMgr *client_file_mgr;
 define_holder(IClientFileMgr, client_file_mgr);
 
 #define DEFAULT_PCHANNELS	256
+#include <string>
 
 #ifndef NOLITHTECH
 extern int32 g_CV_LTDMConsoleOutput;

--- a/runtime/kernel/src/sys/sdl2/InputSDL2.cpp
+++ b/runtime/kernel/src/sys/sdl2/InputSDL2.cpp
@@ -9,6 +9,7 @@
 #endif
 #include "sdl2_scancode_to_dinput.h"
 #include <algorithm>
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/runtime/kernel/src/sys/win/dsys_interface.cpp
+++ b/runtime/kernel/src/sys/win/dsys_interface.cpp
@@ -771,7 +771,8 @@ LTRESULT dsi_DoErrorMessage(const char *pMessage) {
 
 void dsi_MessageBox(const char *pMessage, const char *pTitle) {
     int i;
-    i = MessageBox(g_ClientGlob.m_hMainWnd, pMessage, pTitle, MB_OK);
+    i = SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+        pTitle, pMessage, g_ClientGlob.m_window);
 }
 
 LTRESULT dsi_GetVersionInfo(LTVersionInfo &info) {


### PR DESCRIPTION
1. Windows: Fix compilation errors under Visual Studio 2022.
2. Windows: Fix some message boxes not appearing.