### PR TITLE
Use more Windows runtime/client	code when using DXVK.

### DIFF
--- a/runtime/client/CMakeLists.txt
+++ b/runtime/client/CMakeLists.txt
@@ -177,7 +177,6 @@ if(WIN32)
 	../kernel/src/sys/win/dutil.cpp
 	../kernel/src/sys/win/input.cpp
 	../kernel/src/sys/win/InputSim.cpp
-	../kernel/src/sys/win/interface_helpers.cpp
 	../kernel/src/sys/win/load_pcx.cpp
 	../kernel/src/sys/win/ltdirectmusicloader.cpp
 	../kernel/src/sys/win/lthread.cpp
@@ -250,6 +249,7 @@ if (WIN32 OR ENABLE_DXVK)
 	../model/src/sys/d3d/d3d_model_load.cpp
 	../render_b/src/sys/d3d/d3ddrawprim.cpp
 	../render_b/src/sys/d3d/d3dtexinterface.cpp
+	../kernel/src/sys/win/interface_helpers.cpp
 	../kernel/src/sys/win/render.cpp
 	src/sys/win/winclientde_impl.cpp
     )

--- a/runtime/client/src/sys/linux/linuxconsole_impl.cpp
+++ b/runtime/client/src/sys/linux/linuxconsole_impl.cpp
@@ -1473,8 +1473,9 @@ void CConsole::OnKeyPress(uint32 key)
 	}
 }
 
+#ifndef USE_DXVK
 uint32 GetInterfaceSurfaceMemory()
 {
 	return 0;
 }
-
+#endif

--- a/runtime/client/src/sys/win/winclientde_impl.cpp
+++ b/runtime/client/src/sys/win/winclientde_impl.cpp
@@ -42,11 +42,7 @@ extern int32 g_CV_ForceClear;
 extern int32 g_nConsoleLines;
 
 // The screen surface.. treated specially.
-#ifndef USE_DXVK
 CisSurface g_ScreenSurface;
-#else
-HSURFACE g_ScreenSurface;
-#endif
 // The render struct we're using..
 RenderStruct *g_pCisRenderStruct = LTNULL;
 
@@ -74,7 +70,6 @@ uint32 g_nScreenPixelBytes;
 // Used when restoring surfaces.
 static PFormat g_PrevScreenFormat;
 static uint32 g_nPrevScreenPixelBytes;
-
 
 
 static LTRESULT cis_WarpSurfaceToSurface(HSURFACE hDest, HSURFACE hSrc, 
@@ -137,7 +132,6 @@ static LTRESULT cis_OpaqueDraw(bool bSameSurface,
 	return LT_OK;
 }
 
-#ifndef USE_DXVK
 template<class P>
 inline void cis_SolidColorDrawLine(uint8 *pSrcLine, uint8 *pDestLine, uint32 width, P *pixelType)
 {
@@ -301,7 +295,7 @@ inline void cis_MaskedDrawLine32(uint8 *pSrcLine, uint8 *pDestLine, uint32 width
 		++dest;
 	}
 }
-#endif
+
 template<class P>
 inline void cis_MaskedDrawLine(uint8 *pSrcLine, uint8 *pDestLine, uint32 width,
 							   uint8 *pMaskLine, uint32 maskMaskX, uint32 maskX, P *pixelType)
@@ -331,7 +325,6 @@ inline void cis_MaskedDrawLine(uint8 *pSrcLine, uint8 *pDestLine, uint32 width,
 // If the surface's contents are dirty, reoptimize the surface.
 static void cis_OptimizeDirty(CisSurface *pSurface)
 {
-#ifndef USE_DXVK
 	if(!pSurface)
 		return;
 	
@@ -340,10 +333,8 @@ static void cis_OptimizeDirty(CisSurface *pSurface)
 		g_pCisRenderStruct->OptimizeSurface(pSurface->m_hBuffer, pSurface->m_OptimizedTransparentColor);
 		pSurface->m_Flags &= ~SURFFLAG_OPTIMIZEDIRTY;
 	}
-#endif
 }
 
-#ifndef USE_DXVK
 static LTRESULT cis_MaskedDraw(bool bSameSurface,
 	uint8 *pSrcLine, uint8 *pDestLine,
 	long srcPitch, long destPitch, LTRect *pSrcRect, LTRect *pDestRect)
@@ -510,7 +501,6 @@ static void cis_InternalBitmapToSurface(CisSurface *pDest, LoadedBitmap *pSrc,
 	LTRect srcRect, destRect;
 	FMConvertRequest request;
 	LTRESULT dResult;
-
 
 	if(pSrcRect)
 	{
@@ -709,7 +699,6 @@ static LTRESULT cis_InternalTransformSurfaceToSurface(HSURFACE hDest, HSURFACE h
 	else
 		return cis_WarpSurfaceToSurface(hDest, hSrc, warpPoints, 4);
 }
-#endif
 
 // tType 0 = transparent
 // tType 1 = solid
@@ -717,14 +706,11 @@ static LTRESULT cis_InternalTransformSurfaceToSurface(HSURFACE hDest, HSURFACE h
 
 static LTRESULT cis_InternalScaleSurfaceToSurface(HSURFACE hDest, HSURFACE hSrc, LTRect *pDestRect, LTRect *pSrcRect, int tType, HLTCOLOR tColor, HLTCOLOR fillColor)
 {
-#ifndef USE_DXVK
 	LTRect destRect, srcRect;
 	CisSurface *pSrc, *pDest;
 	LTWarpPt warpPoints[4];
 	LTBOOL bIsInside;
 	BlitRequest blitRequest;
-
-
 	pSrc = (CisSurface*)hSrc;
 	pDest = (CisSurface*)hDest;
 	if(!pSrc || !pDest)
@@ -785,7 +771,6 @@ static LTRESULT cis_InternalScaleSurfaceToSurface(HSURFACE hDest, HSURFACE hSrc,
 		}
 	}
 
-
 	warpPoints[0].dest_x = (float)destRect.left;
 	warpPoints[0].dest_y = (float)destRect.top;
 	warpPoints[0].source_x = (float)srcRect.left;
@@ -812,13 +797,8 @@ static LTRESULT cis_InternalScaleSurfaceToSurface(HSURFACE hDest, HSURFACE hSrc,
 		return cis_WarpSurfaceToSurface(hDest, hSrc, warpPoints, 4);
 	else// if(tType == 2)
 		return cis_WarpSurfaceToSurfaceSolidColor(hDest, hSrc, warpPoints, 4, tColor, fillColor);
-#else
-	//STUB
-	return LT_OK;
-#endif
 }
 
-#ifndef USE_DXVK
 static void cis_DeleteSurfaceBuffer(CisSurface *pSurface)
 {
 	if(pSurface->m_hBuffer)
@@ -838,11 +818,9 @@ static void cis_DeleteSurfaceBackupBuffer(CisSurface *pSurface)
 		pSurface->m_pBackupBuffer = LTNULL;
 	}
 }
-#endif
 
 static bool cis_BackupSurface(CisSurface *pSurface)
 {
-#ifndef USE_DXVK
 	// Don't back it up if it's already been deleted
 	if (!pSurface->m_hBuffer)
 		return true;
@@ -873,16 +851,12 @@ static bool cis_BackupSurface(CisSurface *pSurface)
 
 	// Get rid of the buffer.
 	cis_DeleteSurfaceBuffer(pSurface);
-#else
-	//STUB
-#endif
 	return true;
 }
 
 
 static bool cis_RestoreSurface(CisSurface *pSurface)
 {
-#ifndef USE_DXVK
 	uint32 surfWidth, surfHeight;
 	FMConvertRequest request;
 	LTRESULT dResult;
@@ -930,9 +904,6 @@ static bool cis_RestoreSurface(CisSurface *pSurface)
 	{
 		g_pCisRenderStruct->OptimizeSurface(pSurface->m_hBuffer, pSurface->m_OptimizedTransparentColor);
 	}
-#else
-	//STUB
-#endif
 	return true;
 }
 
@@ -973,7 +944,6 @@ static bool cis_RestoreSurfaces()
 
 static void cis_DeleteSurfaces()
 {
-#ifndef USE_DXVK
 	GPOS pos;
 	CisSurface *pSurface;
 
@@ -988,10 +958,8 @@ static void cis_DeleteSurfaces()
 	}
 
 	g_Surfaces.RemoveAll();
-#endif
 }
 
-#ifndef USE_DXVK
 CisSurface* cis_InternalCreateSurface(uint32 width, uint32 height)
 {
 	CisSurface *pSurface;
@@ -1024,7 +992,6 @@ CisSurface* cis_InternalCreateSurface(uint32 width, uint32 height)
 	g_Surfaces.AddHead(pSurface);	
 	return pSurface;
 }
-#endif
 
 // ----------------------------------------------------------------- //
 // Interface implementation functions.
@@ -1112,7 +1079,6 @@ static bool IsHorzSpanSolidColor(uint8 *pBuf, GenericColor color, uint32 width)
 	return true;
 }
 
-#ifndef USE_DXVK
 static LTRESULT cis_GetBorderSize(HSURFACE hSurface, HLTCOLOR hColor, LTRect *pRect)
 {
 	CisSurface *pSurface;
@@ -1148,11 +1114,9 @@ static LTRESULT cis_GetBorderSize(HSURFACE hSurface, HLTCOLOR hColor, LTRect *pR
 	g_pCisRenderStruct->UnlockSurface(pSurface->m_hBuffer);	
 	return LT_OK;
 }
-#endif
 
 static LTRESULT cis_OptimizeSurface(HSURFACE hSurface, HLTCOLOR hTransparentColor)
 {
-#ifndef USE_DXVK
 	CisSurface *pSurface;
 
 	if(!hSurface)
@@ -1187,12 +1151,8 @@ static LTRESULT cis_OptimizeSurface(HSURFACE hSurface, HLTCOLOR hTransparentColo
 		// Just return out.. we'll optimize it when we recreate the surface.
 		return LT_OK;
 	}
-#else
-	return LT_OK; //STUB
-#endif
 }
 
-#ifndef USE_DXVK
 static LTRESULT cis_UnoptimizeSurface(HSURFACE hSurface)
 {
 	CisSurface *pSurface;
@@ -1215,18 +1175,13 @@ static LTRESULT cis_UnoptimizeSurface(HSURFACE hSurface)
 		return LT_OK;
 	}
 }
-#endif
 
 static HSURFACE cis_GetScreenSurface()
 {
 	if(!g_pCisRenderStruct)
 		return LTNULL;
 
-#ifndef USE_DXVK
 	return (HSURFACE)&g_ScreenSurface;
-#else
-	return (HSURFACE)g_ScreenSurface;
-#endif
 }
 
 
@@ -1250,16 +1205,11 @@ static bool cis_LoadPcx(const char *pBitmapName, LoadedBitmap *pBitmap)
 
 static HSURFACE cis_CreateSurface(uint32 width, uint32 height)
 {
-#ifndef USE_DXVK
 	return (HSURFACE)cis_InternalCreateSurface(width, height);
-#else
-	return (HSURFACE)SDL_CreateRGBSurface(0, width, height,32,0,0,0,0);
-#endif
 }
 
 HSURFACE cis_CreateSurfaceFromPcx(LoadedBitmap *pLoadedBitmap)
 {
-#ifndef USE_DXVK
 	CisSurface *pSurface;
 
 	// Create a surface for it.
@@ -1271,9 +1221,6 @@ HSURFACE cis_CreateSurfaceFromPcx(LoadedBitmap *pLoadedBitmap)
 
 	cis_InternalBitmapToSurface(pSurface, pLoadedBitmap, LTNULL, 0, 0);
 	return (HSURFACE)pSurface;
-#else
-	return cis_CreateSurface(32, 32); //STUB
-#endif
 }
 
 
@@ -1355,7 +1302,6 @@ static HSURFACE cis_CreateSurfaceFromBitmap(const char *pBitmapName)
 
 LTRESULT cis_DeleteSurface(HSURFACE hSurface)
 {
-#ifndef USE_DXVK
 	CisSurface *pSurface = (CisSurface*)hSurface;
 
 	if(!pSurface)
@@ -1378,14 +1324,9 @@ LTRESULT cis_DeleteSurface(HSURFACE hSurface)
 		cis_DeleteSurfaceBuffer(pSurface);
 		sb_Free(&g_SurfaceBank, pSurface);
 	}
-#else
-	SDL_Surface *s = (SDL_Surface*)hSurface;
-	SDL_FreeSurface(s);
-#endif
 	return LT_OK;
 }
 
-#ifndef USE_DXVK
 static void* cis_GetSurfaceUserData(HSURFACE hSurf)
 {
 	if(hSurf)
@@ -1448,11 +1389,9 @@ LTRESULT cis_SetPixel(HSURFACE hSurface, uint32 x, uint32 y, HLTCOLOR color)
 	cis_SetDirty(pSurface);
 	return LT_OK;
 }
-#endif
 
 static void cis_GetSurfaceDims(HSURFACE hSurf, uint32 *pWidth, uint32 *pHeight)
 {
-#ifndef USE_DXVK
 	CisSurface *pSurface = (CisSurface*)hSurf;
 
 	if(pSurface)
@@ -1467,19 +1406,8 @@ static void cis_GetSurfaceDims(HSURFACE hSurf, uint32 *pWidth, uint32 *pHeight)
 	{
 		*pWidth = *pHeight = 0;
 	}
-#else
-	if(!hSurf)
-	{
-		return;
-	}
-
-	SDL_Surface *s = (SDL_Surface*)(hSurf);
-	*pWidth = s->w;
-	*pHeight = s->h;
-#endif
 }
 
-#ifndef USE_DXVK
 static bool cis_DrawBitmapToSurface(HSURFACE hDest, const char *pSourceBitmapName, 
 	const LTRect *pSrcRect, int destX, int destY)
 {
@@ -1529,20 +1457,14 @@ LTRESULT cis_DrawSurfaceToSurface(HSURFACE hDest, HSURFACE hSrc,
 	return cis_DoDrawSurfaceToSurface(hDest, hSrc, pSrcRect, destX, destY, cis_OpaqueDraw);
 }
 
-#endif
-
 static LTRESULT cis_DrawSurfaceToSurfaceTransparent(HSURFACE hDest, HSURFACE hSrc, 
 	LTRect *pSrcRect, int destX, int destY, HLTCOLOR hColor)
 {
-#ifndef USE_DXVK
 	if(!g_pCisRenderStruct)
 		RETURN_ERROR(1, DrawSurfaceToSurfaceTransparent, LT_NOTINITIALIZED);
 
 	cis_SetTransparentColor(hColor);
 	return cis_DoDrawSurfaceToSurface(hDest, hSrc, pSrcRect, destX, destY, cis_TransparentDraw);
-#else
-	return LT_OK;
-#endif
 }
 
 
@@ -1576,7 +1498,6 @@ static LTRESULT cis_ScaleSurfaceToSurfaceSolidColor(HSURFACE hDest, HSURFACE hSr
 	return cis_InternalScaleSurfaceToSurface(hDest, hSrc, pDestRect, pSrcRect, 2, hTransColor, hFillColor);
 }
 
-#ifndef USE_DXVK
 static LTRESULT cis_WarpSurfaceToSurface(HSURFACE hDest, HSURFACE hSrc, 
 	LTWarpPt *pCoords, int nCoords)
 {
@@ -1630,11 +1551,9 @@ static LTRESULT cis_TransformSurfaceToSurfaceTransparent(HSURFACE hDest, HSURFAC
 	return cis_InternalTransformSurfaceToSurface(hDest, hSrc, pRotOrigin, destX, destY,
 		angle, scaleX, scaleY, true, hColor);
 }
-#endif
 
 static LTRESULT cis_FillRect(HSURFACE hDest, LTRect *pRect, HLTCOLOR hColor)
 {
-#ifndef USE_DXVK
 	LTRect theRect, tempRect;
 	LTBOOL bIsVisible;
 	CisSurface *pDest;
@@ -1680,19 +1599,11 @@ static LTRESULT cis_FillRect(HSURFACE hDest, LTRect *pRect, HLTCOLOR hColor)
 	{
 		RETURN_ERROR(1, FillRect, LT_ERROR);
 	}
-#else
-	if(!hDest)
-		return LT_ERROR;
-	SDL_Surface *s = (SDL_Surface *)hDest;
-	pRect->Init(0, 0, s->w, s->h);
-	return LT_OK;
-#endif
 }
 
 
 static LTRESULT cis_GetSurfaceAlpha(HSURFACE hSurface, float &alpha)
 {
-#ifndef USE_DXVK
 	FN_NAME(cis_GetSurfaceAlpha);
 	CisSurface *pSurface;
 
@@ -1700,18 +1611,12 @@ static LTRESULT cis_GetSurfaceAlpha(HSURFACE hSurface, float &alpha)
 	
 	pSurface = (CisSurface*)hSurface;
 	alpha = pSurface->m_Alpha;
-#else
-    uint8 nAlpha=0;
-    SDL_GetSurfaceAlphaMod((SDL_Surface*)hSurface, &nAlpha);
-    alpha = (float)nAlpha / 255.0f;
-#endif
 	return LT_OK;
 }
 
 
 static LTRESULT cis_SetSurfaceAlpha(HSURFACE hSurface, float alpha)
 {
-#ifndef USE_DXVK
 	FN_NAME(cis_SetSurfaceAlpha);
 	CisSurface *pSurface;
 
@@ -1720,10 +1625,6 @@ static LTRESULT cis_SetSurfaceAlpha(HSURFACE hSurface, float alpha)
 	pSurface = (CisSurface*)hSurface;
 	pSurface->m_Alpha = LTCLAMP(alpha, 0.0f, 1.0f);
 	return LT_OK;
-#else
-	SDL_SetSurfaceAlphaMod((SDL_Surface*)hSurface, (0xff & (int)(255.0f * alpha)));
-    return LT_OK;
-#endif
 }
 
 
@@ -2097,7 +1998,6 @@ void cis_Init()
 	ilt_client->DeleteColor = cis_DeleteColor;
 	ilt_client->SetupColor1 = cis_SetupColor1;
 	ilt_client->SetupColor2 = cis_SetupColor2;
-#ifndef USE_DXVK
 	ilt_client->GetBorderSize = cis_GetBorderSize;
 	ilt_client->UnoptimizeSurface = cis_UnoptimizeSurface;
 	ilt_client->GetSurfaceUserData = cis_GetSurfaceUserData;
@@ -2114,7 +2014,6 @@ void cis_Init()
 	ilt_client->WarpSurfaceToSurface = cis_WarpSurfaceToSurface;
 	ilt_client->WarpSurfaceToSurfaceTransparent = cis_WarpSurfaceToSurfaceTransparent;
 	ilt_client->WarpSurfaceToSurfaceSolidColor = cis_WarpSurfaceToSurfaceSolidColor;
-#endif
 	ilt_client->OptimizeSurface = cis_OptimizeSurface;
 	ilt_client->GetSurfaceDims = cis_GetSurfaceDims;
 	ilt_client->GetScreenSurface = cis_GetScreenSurface;
@@ -2136,10 +2035,8 @@ void cis_Init()
 
 	ilt_client->GetSurfaceAlpha = cis_GetSurfaceAlpha;
 	ilt_client->SetSurfaceAlpha = cis_SetSurfaceAlpha;
-#ifndef USE_DXVK
 	// Init the screen surface.
 	g_ScreenSurface.m_Flags = SURFFLAG_SCREEN;
-#endif
 
 	// Init the allocators..
 	sb_Init(&g_SurfaceBank, sizeof(CisSurface), 10);
@@ -2157,29 +2054,21 @@ void cis_Init()
 
 void cis_Term()
 {
-#ifndef USE_DXVK
 	cis_DeleteSurfaces();
 	
 	// Shutdown the allocators.
 	sb_Term(&g_SurfaceBank);
-
+#ifndef USE_DXVK
 	tmgr_Term();
-	
-	g_pCisRenderStruct = LTNULL;
 #endif
+	g_pCisRenderStruct = LTNULL;
 }
 
 bool cis_RendererIsHere(RenderStruct *pStruct)
 {
 	g_pCisRenderStruct = pStruct;
-#ifndef USE_DXVK
 	g_ScreenSurface.m_Width = pStruct->m_Width;
 	g_ScreenSurface.m_Height = pStruct->m_Height;
-#else
-	int x, y;
-	SDL_GetWindowSize(g_ClientGlob.m_window, &x, &y);
-	g_ScreenSurface = cis_CreateSurface(x, y);
-#endif
 	pStruct->GetScreenFormat(&g_ScreenFormat);
 	g_nScreenPixelBytes = g_ScreenFormat.GetBytesPerPixel();
 
@@ -2190,18 +2079,13 @@ bool cis_RendererIsHere(RenderStruct *pStruct)
 bool cis_RendererGoingAway()
 {
 	bool bRet;
-#ifndef USE_DXVK
 	g_PrevScreenFormat = g_ScreenFormat;
 	g_nPrevScreenPixelBytes = g_nScreenPixelBytes;
-#else
-	cis_DeleteSurface(g_ScreenSurface);
-#endif
 	bRet = cis_BackupSurfaces();
 	g_pCisRenderStruct = LTNULL;
 	return bRet;
 }
 
-#ifndef USE_DXVK
 // For memorywatch.cpp.
 unsigned long GetInterfaceSurfaceMemory()
 {
@@ -2223,12 +2107,3 @@ unsigned long GetInterfaceSurfaceMemory()
 
 	return total;
 }
-#endif
-
-
-
-
-
-
-
-

--- a/runtime/kernel/src/sys/linux/interface_helpers.h
+++ b/runtime/kernel/src/sys/linux/interface_helpers.h
@@ -1,3 +1,6 @@
+#ifdef USE_DXVK
+#include "../win/interface_helpers.h"
+#else
 // This module implements lots of helpful rectangle and 2d clipping
 // routines used for interface stuff.
 #ifndef __INTERFACE_HELPERS_H__
@@ -58,3 +61,4 @@ inline void* cis_LockSurface(CisSurface *pSurface, long &pitch, LTBOOL bSetDirty
 inline void cis_UnlockSurface(CisSurface *pSurface) {} // stub
 inline LTBOOL IsColorTransparent(HLTCOLOR hColor) { return LTFALSE; } // stub
 #endif  // __INTERFACE_HELPERS_H__
+#endif  // USE_DXVK

--- a/runtime/kernel/src/sys/win/interface_helpers.h
+++ b/runtime/kernel/src/sys/win/interface_helpers.h
@@ -65,7 +65,7 @@ public:
 };
 
 
-
+#ifndef USE_DXVK
 // The font structure.
 class LTFont : public CGLLNode
 {
@@ -74,7 +74,9 @@ class LTFont : public CGLLNode
         HFONT   m_hFont;
 
 };
-
+#else
+class LTFont : public CGLLNode {}; // stub
+#endif
 
 // The surface structure.. 
 class CisSurface : public CGLLNode


### PR DESCRIPTION
This restores some graphics on Linux, such as cutscene fade, letterboxes, and pause tint.