### PR TITLE
Fix Visual Studio crashes related to nans and uninitialized variables.

### DIFF
--- a/NOLF2/ClientShellDLL/ClientShellShared/ExplosionFX.cpp
+++ b/NOLF2/ClientShellDLL/ClientShellShared/ExplosionFX.cpp
@@ -82,7 +82,7 @@ LTBOOL CExplosionFX::CreateObject(ILTClient *pClientDE)
 
 		// Determine what container we're in...
 
-		ContainerCode eCode;
+		ContainerCode eCode = CC_NO_CONTAINER;
 		HLOCALOBJ objList[1];
         LTVector vTestPos = m_cs.vPos;
         uint32 dwNum = ::GetPointContainers(vTestPos, objList, 1, ::GetLiquidFlags());

--- a/NOLF2/ClientShellDLL/ClientShellShared/SFXMgr.cpp
+++ b/NOLF2/ClientShellDLL/ClientShellShared/SFXMgr.cpp
@@ -278,6 +278,12 @@ void CSFXMgr::HandleSFXMsg(HLOCALOBJ hObj, ILTMessage_Read *pMsg)
 			debris.vPos			= pMsg->ReadCompPos();
 			debris.nDebrisId	= pMsg->Readuint8();
 
+			if (std::isnan(debris.rRot[0]) || std::isnan(debris.rRot[1]) ||
+				std::isnan(debris.rRot[2]) || std::isnan(debris.rRot[3]))
+			{
+				debris.rRot.Identity();
+			}
+
 			CreateSFX(nId, &debris);
 		}
 		break;


### PR DESCRIPTION
Specifically, this fixes a crash when exploding the gas tank in the inner yard in Chapter 5.